### PR TITLE
remove discussion section from all yeps

### DIFF
--- a/yeps/yep-001.md
+++ b/yeps/yep-001.md
@@ -180,10 +180,6 @@ However, if extended discussion takes place in an alternate issue, they should a
 Updates are performed using GitLab Merge Requests to the [yeps repository](https://gitlab.com/yaq/yeps) which update the markdown files in the `yeps` folder.
 Updates to YEPs MUST achieve consensus among the core team.
 
-# Discussion
-
-Discussion can be found on the [GitLab issue](https://gitlab.com/yaq/yeps/-/issues/7) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/yeps/yep-012.md
+++ b/yeps/yep-012.md
@@ -35,10 +35,6 @@ The canonical reference for required and suggested YEP content is <a href="../00
 
 # Rejected Ideas
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/8) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/yeps/yep-100.md
+++ b/yeps/yep-100.md
@@ -175,10 +175,6 @@ This was an idea for reducing _some_ of the size burden incumbent on JSON for tr
 
 Using base64 introduces additional complexity, and requires copying data into new memory locations, something that at least in theory can be avoided with msgpack in many cases.
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/1) for this YEP.
-
 # Copyright
 
 Much of the specification text itself is mirrored from that in the [JSON-RPC v2 specification](https://www.jsonrpc.org/specification). As such, their copyright notice applies to sections taken verbatim, or nearly so:

--- a/yeps/yep-101.md
+++ b/yeps/yep-101.md
@@ -34,10 +34,6 @@ Additionally, yaq ecosystem tools which scan to identify daemons will only look 
 
 This port is specified in the configuration file [YEP 102](https://yeps.yaq.fyi/102).
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/2) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the

--- a/yeps/yep-102.md
+++ b/yeps/yep-102.md
@@ -71,10 +71,6 @@ Common identifying information include: `make` (manufacturer), `model` (identifi
 
 The configuration file MUST be read from the file at daemon startup ONLY (restarting is considered "startup", and MUST re-read the configuration file in case changes were made).
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/3) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the

--- a/yeps/yep-103.md
+++ b/yeps/yep-103.md
@@ -64,10 +64,6 @@ In general, use of `get_state` for normal operation (i.e. not debugging) is disc
 There are no keys required by default, however Traits or individual daemons MAY require State variables.
 All such keys will be listed in the daemon [Avro protocol](../107).
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/4) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the

--- a/yeps/yep-104.md
+++ b/yeps/yep-104.md
@@ -48,10 +48,6 @@ The entry point SHALL accept the option `--verbose` and the short form `-v`, whi
 
 The entry point SHALL accept the option `--protocol` which prints the [YEP-107](../107) Avro protocol json.
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/5) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the

--- a/yeps/yep-105.md
+++ b/yeps/yep-105.md
@@ -49,10 +49,6 @@ yaq daemon versions SHOULD reach 1.0.0 as soon as reasonable.
 [Zero-based versioning](https://0ver.org/) results in a less semantically meaningful ecosystem.
 Typically, a yaq daemon SHOULD reach 1.0.0 as soon as it is put into everyday use on one or more instruments.
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/9) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/yeps/yep-106.md
+++ b/yeps/yep-106.md
@@ -94,10 +94,6 @@ Daemons SHALL only write log-files when the [YEP-102](../102) config option `log
 
 A future version of this YEP will specify the RPC log access.
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/10) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/yeps/yep-107.md
+++ b/yeps/yep-107.md
@@ -91,10 +91,6 @@ Used only for building documentation.
 
 - [YEP-100](../100) - No schemas, wish to use an existing standard
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/11) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/yeps/yep-110.md
+++ b/yeps/yep-110.md
@@ -147,10 +147,6 @@ def ext_hook(code, data):
 These were deemed verbose due to each element needing to specify its type.
 For large arrays, this is a fair amount of more data.
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/6) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the

--- a/yeps/yep-111.md
+++ b/yeps/yep-111.md
@@ -152,10 +152,6 @@ has-limits ([YEP-303](https://yeps.yaq.fyi/303/))
 }
 ```
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/23) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/yeps/yep-112.md
+++ b/yeps/yep-112.md
@@ -67,10 +67,6 @@ If no daemons are found the bus should exit with an error.
 
 Abstracting away bus interfaces as RPC layers.
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/26) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/yeps/yep-113.md
+++ b/yeps/yep-113.md
@@ -86,10 +86,6 @@ Given that, sending of datatypes not specified here is STRONGLY discouraged, and
 
 Implementations are encouraged to automatically return language-native ndarray objects rather than returning the dictionary representing the map as transmitted.
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/27) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the

--- a/yeps/yep-300.md
+++ b/yeps/yep-300.md
@@ -120,10 +120,6 @@ response: string
 
 Daemon state toml file dumped as a as string.
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/14) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/yeps/yep-301.md
+++ b/yeps/yep-301.md
@@ -105,10 +105,6 @@ while client.busy():
 record(client.get_position()
 ```
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/12) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/yeps/yep-302.md
+++ b/yeps/yep-302.md
@@ -72,10 +72,6 @@ response: {'type': 'map', 'values': ['null', 'string']}
 
 Get current channel units.
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/15) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/yeps/yep-303.md
+++ b/yeps/yep-303.md
@@ -62,10 +62,6 @@ response: boolean
 
 Check if a given position is within daemon limits.
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/16) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/yeps/yep-304.md
+++ b/yeps/yep-304.md
@@ -52,10 +52,6 @@ parameter: turret: string
 
 Set the turret to a given identifier.
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/21) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/yeps/yep-305.md
+++ b/yeps/yep-305.md
@@ -33,10 +33,6 @@ Daemons with this trait need only implement one message.
 
 Initiates the homing procedure. The daemon will report as busy during the homing procedure. After the homing procedure is complete, the daemon will return to the current destination.
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/20) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/yeps/yep-306.md
+++ b/yeps/yep-306.md
@@ -21,10 +21,6 @@ See built documentation at at [yaq.fyi](https://yaq.fyi/traits/uses-serial).
 
 # Proposal
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/19) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/yeps/yep-307.md
+++ b/yeps/yep-307.md
@@ -21,10 +21,6 @@ See built documentation at at [yaq.fyi](https://yaq.fyi/traits/uses-uart).
 
 # Proposal
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/18) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/yeps/yep-308.md
+++ b/yeps/yep-308.md
@@ -21,10 +21,6 @@ See built documentation at at [yaq.fyi](https://yaq.fyi/traits/uses-i2c).
 
 # Proposal
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/17) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/yeps/yep-309.md
+++ b/yeps/yep-309.md
@@ -81,10 +81,6 @@ returns: string
 Get current identifier string.
 Current identifier may be None.
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/13) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/yeps/yep-310.md
+++ b/yeps/yep-310.md
@@ -55,10 +55,6 @@ Initiate a measurement. Returns integer, measurement ID.
 
 Stop looping measurement.
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/21) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.

--- a/yeps/yep-311.md
+++ b/yeps/yep-311.md
@@ -70,10 +70,6 @@ Keys used in get_channel_mappings
 At one point in yaq development, mappings were included simply as additional channels.
 While elegantly simple, this idea proved insufficient.
 
-# Discussion
-
-Discussion can be found on the [gitlab issue](https://gitlab.com/yaq/yeps/-/issues/25) for this YEP.
-
 # Copyright
 
 This document is placed in the public domain or under the CC0-1.0-Universal license, whichever is more permissive.


### PR DESCRIPTION
The idea to have a discussion section was nice, but it just was never used in practice. We discuss ideas in many places, and any information of significance to future readers should be put into the YEP itself.

I don't believe that this change warrants an "update" to the YEP.